### PR TITLE
Require emitLog to have at least two required args (key + arg)

### DIFF
--- a/src/stats/mmd.ts
+++ b/src/stats/mmd.ts
@@ -82,7 +82,7 @@ export const endGameStats = ( winner: "sheep" | "wolves", desynced: boolean ): v
 
 	} catch ( err ) {
 
-		emitLog( err );
+		emitLog( "endGameStats", err );
 
 	}
 

--- a/src/util/emitLog.ts
+++ b/src/util/emitLog.ts
@@ -5,11 +5,12 @@ import { MMD__DefineEvent, MMD__LogEvent } from "../stats/w3mmd";
 import { isSandbox } from "../shared";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const emitLog = ( key: string, ...args: Array<any> ): void => {
+export const emitLog = ( key: string, arg: string, ...args: Array<any> ): void => {
 
-	const message = args.map( v => termToString( v, false ) ).join( " " );
+	const allArgs = [ arg, ...args ];
+	const message = allArgs.map( v => termToString( v, false ) ).join( " " );
 	MMD__LogEvent( "log", key, message );
-	if ( isSandbox() ) log( key, ...args );
+	if ( isSandbox() ) log( key, ...allArgs );
 
 };
 


### PR DESCRIPTION
Before it just required the key, which can accidentally result in not having a key (thus no context).