### PR TITLE
WC3Stats documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The classic Warcraft 3 map.
 [![tests](https://github.com/voces/fixus/workflows/test/badge.svg)](https://github.com/voces/fixus/actions?query=workflow%3Atest)
 [![Discord](https://img.shields.io/discord/232301193718661121)](https://discord.gg/Y4dHvwX)
 
-[Change log](CHANGELOG.md)
+[Change log](docs/CHANGELOG.md)
 
 ## Development
 This is a TypeScript map. This means that while object editing, terraining, and most other parts of editing the map still occurs in the World Editor, the custom code is written in TypeScript and transpiled to Lua. The relevant directories are:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # Version 11
 ## Features
-- Teams are picked in game
+- Teams are picked in game. If too many players want one team, players are, by default, randomly drafted until the desired teams are reached. Optionally, the map will bias towards repeat players attempting to play on a different team, but only if wc3stats is running. Read more at wc3stats.sheeptag.net.
 - Added Bloodlust on save or kill
 - Added Compact Mode on Factory Farms
 - Default values are shown in command help

--- a/docs/wc3stats.md
+++ b/docs/wc3stats.md
@@ -22,5 +22,7 @@ team). This functionality requires the replay uploader program
 
 1. Download [W3CStats.exe](https://wc3stats.com/auto-uploader)
 2. Run `WC3Stats.exe`
-3. Open the program _Settings_ file
-4. Add `api.w3x.io` to the `whitelist` array
+3. Open the program _Settings_ file:\
+![image](https://user-images.githubusercontent.com/4513209/81761198-2d003580-947e-11ea-80fe-5ec050f8871e.png)
+4. Add `api.w3x.io` to the `whitelist` array:\
+![image](https://user-images.githubusercontent.com/4513209/81761382-a566f680-947e-11ea-8def-21b1537b995d.png)

--- a/docs/wc3stats.md
+++ b/docs/wc3stats.md
@@ -1,0 +1,26 @@
+# wc3stats
+
+[wc3stats.com](https://wc3stats.com/) is a user-made service that processes
+replays and can act as a bridge to allow maps to make network calls. Fixus and
+other Sheep Tag maps use the service to track Elo scores and other statistics.
+You can view Sheep Tag leaderboards, statistics, and games at
+[wc3stats.com/sheep-tag](https://wc3stats.com/sheep-tag).
+
+# Replays
+Replays must be uploaded to the service to have any effect. This can be done
+manually at [wc3stats.com/upload](https://wc3stats.com/upload) or through use
+of the replay uploader program
+([download](https://wc3stats.com/auto-uploader)).
+
+# NetworkIO
+NetworkIO is a protocol to allow maps to make network requests in-game. This is
+used by Fixus to bias the team selection phase against players who play the
+same team repeatidly (but only if an outsized of players want to play on that
+team). This functionality requires the replay uploader program
+([download](https://wc3stats.com/auto-uploader)) and requires you add
+`api.w3x.io` to the whitelist. You can do this by:
+
+1. Download [W3CStats.exe](https://wc3stats.com/auto-uploader)
+2. Run `WC3Stats.exe`
+3. Open the program _Settings_ file
+4. Add `api.w3x.io` to the `whitelist` array

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -11,7 +11,7 @@ const listBullet = [ "•", "-", "∙" ];
 
 export const generateTs = async (): Promise<string> => {
 
-	const data = await fs.readFile( "CHANGELOG.md", { encoding: "utf-8" } );
+	const data = await fs.readFile( "docs/CHANGELOG.md", { encoding: "utf-8" } );
 
 	const versions: Array<Version> = [];
 	const tokens = lexer( data );

--- a/src/misc/changelog.ts
+++ b/src/misc/changelog.ts
@@ -4,7 +4,7 @@
 export const changelog = [
 	{ title: "Version 11", content: [
 		"Features",
-		"• Teams are picked in game",
+		"• Teams are picked in game. If too many players want one team, players are, by default, randomly drafted until the desired teams are reached. Optionally, the map will bias towards repeat players attempting to play on a different team, but only if wc3stats is running. Read more at wc3stats.sheeptag.net.",
 		"• Added Bloodlust on save or kill",
 		"• Added Compact Mode on Factory Farms",
 		"• Default values are shown in command help",

--- a/src/misc/stats.ts
+++ b/src/misc/stats.ts
@@ -63,7 +63,7 @@ emitCustom( "version", compiletime( () => {
 	// eslint-disable-next-line @typescript-eslint/no-var-requires
 	const fs = require( "fs" );
 
-	const file = fs.readFileSync( "CHANGELOG.md", { encoding: "utf-8" } );
+	const file = fs.readFileSync( "docs/CHANGELOG.md", { encoding: "utf-8" } );
 	return file.split( "\n" )[ 1 ].split( " " )[ 2 ];
 
 } ) );


### PR DESCRIPTION
PR adds a call out to wc3stats.com and explains how to configure it for Fixus support.